### PR TITLE
Step state to 'null' if no template selected.

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -13,6 +13,8 @@ export default function App() {
   useEffect(() => {
     if (template) {
       dispatch({ type: "initialize", payload: { template } });
+    } else {
+      dispatch({ type: "null" });
     }
   }, [template]);
 
@@ -39,6 +41,9 @@ export default function App() {
         const card = { ...state.card };
         const ledger = { ...state.cache };
         return { card, ledger, cache: null };
+      }
+      case "null": {
+        return null;
       }
       default: {
         console.error(

--- a/app/src/components/Selector/index.js
+++ b/app/src/components/Selector/index.js
@@ -4,7 +4,8 @@ export default function({ cards, onChanged }) {
   const [selected, setSelected] = useState("none");
 
   useEffect(() => {
-    onChanged(cards.find(card => `${card.name}` === selected));
+    const template = cards.find(card => `${card.name}` === selected);
+    template ? onChanged(template) : onChanged(null);
   }, [cards, selected, onChanged]);
 
   const handleSelection = evt => {


### PR DESCRIPTION
This PR fixes a bug in the card selector.

Before this fix, there was no way to return to the "Landing" page after selecting a card. The expectation would be that "Select a card" from the drop down would do so.

With this fix, "Select a card" will return the user to the Landing page.